### PR TITLE
CMAKE: Update CMakefiles to allow building in PTXDist environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 ﻿cmake_minimum_required (VERSION 3.10)
+cmake_policy(SET CMP0074 NEW)
+
 
 #
 # set project name/properties
@@ -74,7 +76,7 @@ include(GNUInstallDirs)
 #
 #	OpenSSL
 #
-find_package(OpenSSL 1.1.0 REQUIRED)
+find_package(OpenSSL 1.1.1 REQUIRED)
 if(OPENSSL_FOUND)
 	message(STATUS "** openSSL Include       : ${OPENSSL_INCLUDE_DIR}")
 	message(STATUS "** openSSL crypto library: ${OPENSSL_CRYPTO_LIBRARY}")

--- a/cmake/FindCYNG.cmake
+++ b/cmake/FindCYNG.cmake
@@ -40,11 +40,13 @@ if(NOT CYNG_FOUND)
     find_path(CYNG_INCLUDE_DIR_SRC
         NAMES 
             cyng/version.hpp
-            cyng/obj/object.h
+			cyng/meta.hpp
+            cyng.h.in
         PATH_SUFFIXES
             cyng
         HINTS
             "${PROJECT_SOURCE_DIR}/../cyng/include"
+			"${PROJECT_SOURCE_DIR}/cyng-*/include"
         PATHS
             /usr/include/
             /usr/local/include/
@@ -60,11 +62,19 @@ if(NOT CYNG_FOUND)
    find_path(CYNG_INCLUDE_DIR_BUILD
         NAMES 
             cyng.h
-         HINTS
+			cross.cmake
+		PATH_SUFFIXES
+			cyng
+			cyng-0.9
+			build
+			v5te
+			build/v5te
+        HINTS
 			"${PROJECT_SOURCE_DIR}/../cyng/build/include"
             "${PROJECT_SOURCE_DIR}/../cyng/v5te/include"
             "${PROJECT_SOURCE_DIR}/../cyng/build/x64/include"
             "${PROJECT_SOURCE_DIR}/../cyng/build/v5te/include"
+			"${PROJECT_SOURCE_DIR}/cyng*/build/v5te/include"
         PATHS
             /usr/include/
             /usr/local/include/
@@ -114,6 +124,7 @@ if(NOT CYNG_FOUND)
 				${__CYNG_BUILD}
 			HINTS
 				"${CYNG_INCLUDE_DIR_BUILD}/.."
+				"${CYNG_INCLUDE_DIR_BUILD}/"
 			PATHS
 				/usr/lib/
 				/usr/local/lib


### PR DESCRIPTION
No absolute paths given, so it should not break any other builds.
Just enhance the FindCyng.cmake file to allow finding the cang library in the PTX-Dist environment.
In the CMakeLists.txt the policy for Variables ending with "_ROOT" was changed to behaviour NEW, which means allow the usage. Before the OLD policy was used, which meant those variables would get ignored.